### PR TITLE
Fixed lifting restrictions after captcha is passed

### DIFF
--- a/new_members_handler.py
+++ b/new_members_handler.py
@@ -57,9 +57,8 @@ class NewMembersHandler:
                                              message_id=callback.message.message_id,
                                              text="Congrats, " + callback.from_user.first_name + ", captcha passed",
                                              reply_markup=None)
-            await self.bot.restrict_chat_member(callback.message.chat.id,
-                                                callback.from_user.id,
-                                                can_send_messages=True,
-                                                can_send_media_messages=True,
-                                                can_send_other_messages=True)
+            await self.bot.restrict_chat_member(
+                callback.message.chat.id,
+                callback.from_user.id,
+                types.ChatPermissions(True, True, True, True, True, True, True, True))
             self.pendingUsers.pop(callback.message.message_id)


### PR DESCRIPTION
Before that we were only lifting **sending messages** restrictions from the users, they still couldn't embed links/create polls. The result is the following:
![ss](https://user-images.githubusercontent.com/49668442/85050106-cf1ee600-b1bf-11ea-8bfd-bdc71ac3107e.jpg)

According to the restrict_chat_member documentation on iaogram ` Pass True for all boolean parameters to lift restrictions from a user.`. So that's what i did now (i've tested, it works!)

Btw i've also tried this way
```
            await self.bot.restrict_chat_member(
                callback.message.chat.id,
                callback.from_user.id,
                callback.message.chat.permissions)
```
but it doesn't work for some reason, seems like you need to pass all parameters `True` indeed