### PR TITLE
Assigned the id of the replied message instead of incremented id

### DIFF
--- a/new_members_handler.py
+++ b/new_members_handler.py
@@ -32,9 +32,9 @@ class NewMembersHandler:
                                             can_send_media_messages=False,
                                             can_send_other_messages=False)
         markup = self.__makeInlineKeyboard()
-        await message.reply("Welcome, {0.first_name},\nAre you a spam bot or a human?"
-                            .format(message.from_user), reply_markup=markup)
-        self.pendingUsers[message.message_id + 1] = message.from_user.id
+        replied_message = await message.reply("Welcome, {0.first_name},\nAre you a spam bot or a human?"
+                                              .format(message.from_user), reply_markup=markup)
+        self.pendingUsers[replied_message.message_id] = message.from_user.id
 
     def __makeInlineKeyboard(self):
         markup = types.InlineKeyboardMarkup(resize_keyboard=True)


### PR DESCRIPTION
This is **not a bug**, but I just thought it would be nice to use the **id** received from bot's reply message instead of incrementing **id** by one

### Explanation
When user joins we receive a **message** with a **new_chat_members** array (you can see this field in https://core.telegram.org/bots/api#message). The reason it's an array and not a single element i think is because you can invite multiple users at a time, but when the user joins via link this array will ALWAYS have one element. Let's say an **id** of this message is _10_
Then we reply to this message with our own message with text "are you a bot or a human", its **id** will be _11_. And we save our message in **pendingUsers** [dictionary](https://www.w3schools.com/python/python_dictionaries.asp) where the key is the **message id** and the value is **user id** (meaning the id of the user that just joined). Because **our message** with welcoming text following the **new_chat_members message**, i'm just incrementing **id** by one (from 10 to 11) to save it in **pendingUsers**. However, a better way of doing it, is to just get an **id** of **our own message**