### PR TITLE
YouTube download only for url only msg and include video url as caption in reply

### DIFF
--- a/command_handler.py
+++ b/command_handler.py
@@ -16,15 +16,14 @@ class CommandHandler:
 
     async def __handleHelp(self, message):
         await message.reply(text="This bot is going to manage cpop.tw.\n"
-                                 "For now it converts a youtube video to mp3 "
+                                 "For now it downloads music from YouTube "
                                  "whenever you send the link and makes new members "
-                                 "go through captcha.\n\n<b>Notice:</b> the youtube "
-                                 "video feature is <b>only</b> available for the chats "
-                                 "that are in the bot's whitelist. If you don't "
-                                 "want the video to be downloaded, just make the link "
-                                 " follow a command, for example <code>/test "
-                                 "youtu.be/somevid</code>. This will <b>not</b> "
-                                 "download the video. \n\n<i>This bot is open source, "
+                                 "go through captcha.\n\n<b>Notice:</b> the YouTube "
+                                 "audio feature is <b>only</b> available for "
+                                 "the chats that are in the bot's whitelist. "
+                                 "To download audio from YouTube, you need to send a "
+                                 "message which contains the YouTube link only."
+                                 "\n\n<i>This bot is open source, "
                                  "the source code is available at</i> "
                                  "cpop.tw/code\n\nRegarding any issues with the bot feel free to "
                                  "contact @konnov", parse_mode=ParseMode.HTML)

--- a/text_handler.py
+++ b/text_handler.py
@@ -4,6 +4,7 @@ import os
 from aiogram import types
 from aiogram.types import ParseMode
 from pytube import YouTube
+from pytube import extract
 from urllib.request import urlopen
 from PIL import Image
 import config
@@ -33,6 +34,7 @@ class TextHandler:
                       .filter(only_audio=True, file_extension='mp4')
                       .order_by('bitrate').desc().first())
             filesize = stream.filesize
+            video_url = "youtu.be/" + extract.video_id(message.text)
             telegram_audio_limit = 52428800
 
             if (filesize < telegram_audio_limit and length < 600):
@@ -42,6 +44,7 @@ class TextHandler:
                 with open(output_audiofile, "rb") as audio, \
                      open(output_thumbnail, "rb") as thumb:
                     await message.reply_audio(audio,
+                                              caption=video_url,
                                               duration=length,
                                               performer=author,
                                               title=title,

--- a/text_handler.py
+++ b/text_handler.py
@@ -16,7 +16,7 @@ class TextHandler:
 
     async def handle(self, message: types.Message):
         text = message.text
-        if text and ('youtu.be' in text or 'youtube.com' in text):
+        if text and (' ' not in text and '\n' not in text) and ('youtu.be' in text or 'youtube.com' in text):
             await self.__handleYoutubeDownload(message)
         elif text == 'ping':
             await message.reply('pong', reply=False)


### PR DESCRIPTION
This includes two commits.

With the first one, it only response to messages which contains the YouTube url only.
Then we just tell users to send the url in a message which includes the url only, this will make the bot less spammy.
And in case someone mentioned a YouTube link in their message, others could copy, paste and send the link to download audio.

And the second commit includes video url as caption in replied audio, this screenshot shows what it looks like before and after.
I want to add this because I think it's good to include the source. In case someone forward this audio elsewhere, the receiver could notice the source of the audio.
It keeps the link in case someone deleted the original message.

<img src="https://user-images.githubusercontent.com/67376103/91958150-79ee6d00-ecf6-11ea-9b57-8318ec60814c.jpg" width="50%" alt="without and with url as caption, before and after">

You can also squash this two commits into one if you want.