### PR TITLE
Switch from pytube to youtube-dl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 /config.py
 /downloads/
+
+# vim
+[._]*.sw[a-p]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Features:
 
 ### Set up
 
-Check `config_example.py` for configuration examples,
-create your own `config.py`, setup virtualenv and install dependencies
+- create `config.py` (check `config_example.py`)
+- install `libwebp-devel`, clear cache of pip (`~/.cache/pip` on linux distro) for building wheel for Pillow
+- setup virtualenv and install dependencies
 
 ```
 $ virtualenv venv

--- a/command_handler.py
+++ b/command_handler.py
@@ -4,21 +4,28 @@ from aiogram.types import ParseMode
 import config
 
 logger = logging.getLogger(__name__)
-HELP = config.help_text
+ABOUT_HTML = config.ABOUT_HTML
+HELP_HTML = config.HELP_HTML
 
 
 class CommandHandler:
-    async def handle(self, message: types.Message):
-        if message.text == "/help" or message.text == "/help@cpop_bot":
+
+    async def handle(self, bot_username, message: types.Message):
+        if message.text in ("/about", "about@" + bot_username):
+            await self.__handleAbout(message)
+        elif message.text in ("/help", "/help@" + bot_username):
             await self.__handleHelp(message)
-        if message.text == "/start":
+        elif message.text == "/start":
             await self.__handleStart(message)
         else:
             logger.debug("USER TYPED UNKNOWN COMMAND " + message.text)
 
+    async def __handleAbout(self, message):
+        await message.reply(text=ABOUT_HTML, parse_mode=ParseMode.HTML)
+
     async def __handleHelp(self, message):
-        await message.reply(text=HELP, parse_mode=ParseMode.HTML)
+        await message.reply(text=HELP_HTML, parse_mode=ParseMode.HTML)
 
     async def __handleStart(self, message):
-        sticker = open('static/hello_animated_sticker.tgs', 'rb')
-        await message.reply_sticker(sticker)
+        with open('static/hello_animated_sticker.tgs', 'rb') as sticker:
+            await message.reply_sticker(sticker)

--- a/config_example.py
+++ b/config_example.py
@@ -1,15 +1,31 @@
-ACCESS_TOKEN = "bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
-WHITELIST_CHAT_ID = ['2011545269', '8557378983', '-1001853277651']
+ACCESS_TOKEN = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+GROUP_CHAT_ID = -1001853277651
+WHITELIST_CHAT_ID = (
+    GROUP_CHAT_ID,
+    2011545269,
+    8557378983
+    )
 USER_CAPTCHA_TIMEOUT_IN_MINUTES = 60
-help_text = ("This bot is going to manage cpop.tw.\n"
-             "For now it downloads music from YouTube "
-             "whenever you send the link and makes new members "
-             "go through captcha.\n\n<b>Notice:</b> the YouTube "
-             "audio feature is <b>only</b> available for "
-             "the chats that are in the bot's whitelist. "
-             "To download audio from YouTube, you need to send a "
-             "message which contains the YouTube link only."
-             "\n\n<i>This bot is open source, "
-             "the source code is available at</i> "
-             "cpop.tw/code\n\nRegarding any issues with the bot feel free to "
-             "contact @konnov")
+AVAILABILITY_HTML = ("This bot only serves cpop.tw group @mandopop and its "
+                     "group members in private chat.")
+CONTACTS_HTML = ("Regarding any issues with the bot feel free to contact "
+                 "@konnov")
+ABOUT_HTML = ("This bot is going to manage cpop.tw.\n"
+              "For now it downloads music from YouTube or SoundCloud "
+              "whenever you send the link and makes new members go through "
+              "captcha." + "\n\n"
+              "<i>Source code available at cpop.tw/code under GPLv3 "
+              "license</i>\n\n" +
+              CONTACTS_HTML)
+HELP_HTML = (AVAILABILITY_HTML + "\n\n"
+             "<b>Usage</b>:\n"
+             "- send a message that only contains a link of a YouTube video "
+             "or a SoundCloud track.\n"
+             "- Playlists are not supported, but you can select multiple "
+             "audio messages and forward them to create playlist instead.\n"
+             "- Your message will be deleted in private chat after the music "
+             "gets successfully uploaded.\n"
+             "- You can get YouTube links with inline bot @vid and use "
+             "them.\n\n" +
+             CONTACTS_HTML)
+DOWNLOAD_DIR = "/tmp/cpop_bot/"

--- a/main.py
+++ b/main.py
@@ -16,7 +16,8 @@ bot = Bot(
 dp = Dispatcher(
     bot=bot,
 )
-textHandler = TextHandler()
+
+textHandler = TextHandler(bot)
 commandHandler = CommandHandler()
 newMembersHandler = NewMembersHandler(bot)
 
@@ -36,7 +37,8 @@ async def process_callback(callback: types.CallbackQuery):
 @dp.message_handler(content_types=types.ContentType.TEXT)
 async def process_text_message(message: types.Message):
     if message.is_command():
-        await commandHandler.handle(message)
+        bot_username = (await bot.get_me()).username
+        await commandHandler.handle(bot_username, message)
     else:
         await textHandler.handle(message)
 

--- a/music_grabber.py
+++ b/music_grabber.py
@@ -1,0 +1,124 @@
+import os
+import logging
+from youtube_dl import YoutubeDL
+from urllib.parse import urlparse
+from urllib.request import Request
+from urllib.request import urlopen
+from PIL import Image
+import config
+
+DOWNLOAD_DIR = config.DOWNLOAD_DIR
+
+logger = logging.getLogger(__name__)
+
+
+class WrongCategoryError(ValueError):
+    pass
+
+
+class WrongFileSizeError(ValueError):
+    pass
+
+
+class MusicDownloader:
+
+    def download(self, input_url, filesize_limit):
+        ydl_opts = {
+                'format': 'bestaudio[protocol^=http]',
+                'outtmpl': DOWNLOAD_DIR + '%(extractor)s_%(id)s.%(ext)s',
+                'writethumbnail': True
+        }
+        ydl = YoutubeDL(ydl_opts)
+        info = ydl.extract_info(input_url, download=False)
+        webpage_info = info['extractor'] + " " + info['id']
+        info_format = next((item for item in info['formats']
+                            if item['format_id'] == info['format_id']),
+                           None)
+
+        if self.__youtubeVideoNotMusic(info):
+            raise WrongCategoryError(webpage_info +
+                                     ": not under Music category")
+
+        audio_filesize = self.__getFileSize(info_format)
+        if int(audio_filesize) < filesize_limit:
+            logger.info(webpage_info + ": downloading...")
+            ydl.process_info(info)
+            info = self.__addDownloadsToInfoDict(info)
+            if self.__filesSuccessfullyDownloaded(info['downloads']):
+                return info
+            else:
+                self.__deleteDownloadedFiles(info['downloads'])
+                raise ValueError(webpage_info +
+                                 ": failed to download audio or thumbnail")
+        else:
+            raise WrongFileSizeError(webpage_info + ": audio file size (" +
+                                     str(audio_filesize) + ") is greater" +
+                                     "than the limit: (" +
+                                     str(filesize_limit) + ")")
+
+    def __youtubeVideoNotMusic(self, info):
+        if info['extractor'] == 'youtube' and \
+                'Music' not in info['categories']:
+            return True
+        else:
+            return False
+
+    def __getFileSize(self, info_format):
+        if 'filesize' in info_format:
+            audio_filesize = info_format['filesize']
+        else:
+            audio_url = info_format['url']
+            http_headers = info_format['http_headers']
+            request_head = Request(audio_url, method='HEAD',
+                                   headers=http_headers)
+            audio_filesize = urlopen(request_head).headers['Content-Length']
+        return audio_filesize
+
+    def __addDownloadsToInfoDict(self, info):
+        webpage_id = info['id']
+        extractor = info['extractor']
+        thumbnail_url = info['thumbnail']
+        basename = DOWNLOAD_DIR + extractor + '_' + webpage_id
+        thumbnail_file = basename + "." + \
+            self.__getFileExtensionFromUrl(thumbnail_url)
+        audio_file = basename + '.' + info['ext']
+        info['downloads'] = {
+                'audio': audio_file,
+                'thumbnail': thumbnail_file
+        }
+        return info
+
+    def __filesSuccessfullyDownloaded(self, info_downloads):
+        return all(os.path.isfile(f) for f in info_downloads.values())
+
+    def __deleteDownloadedFiles(self, info_downloads):
+        for f in info_downloads.values():
+            try:
+                os.remove(f)
+            except OSError:
+                pass
+
+    def __getFileExtensionFromUrl(self, url):
+        url_path = urlparse(url).path
+        basename = os.path.basename(url_path)
+        ext = basename.split(".")[-1]
+        return ext
+
+
+class SquarethumbMaker:
+
+    # https://stackoverflow.com/a/52177551
+    def make_squarethumb(self, thumbnail, output):
+        original_thumb = Image.open(thumbnail)
+        squarethumb = self.__crop_to_square(original_thumb)
+        squarethumb.thumbnail((320, 320), Image.ANTIALIAS)
+        squarethumb.save(output)
+
+    def __crop_to_square(self, img):
+        width, height = img.size
+        length = min(width, height)
+        left = (width - length)/2
+        top = (height - length)/2
+        right = (width + length)/2
+        bottom = (height + length)/2
+        return img.crop((left, top, right, bottom))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
 ujson
 aiogram
-pytube
+youtube-dl
 Pillow


### PR DESCRIPTION
Supports YouTube and SoundCloud, don't check duration but only check file size not reach telegram bot API limitation. Could support more sites but seems does not make much sense to download audio from other sites, YouTube and SoundCloud is enough.

`[bestaudio]` seems fine, from my test, telegram server recognize m4a, webm(opus) and wav format correctly (some songs on SoundCloud provide wav).

By releasing the limitation of audio duration, people could download download mix.

I've updated README, some thumbnails are in WebP format and Pillow needs to be build with WebP support to be able to process those thumbnails. [Pillow documentation](https://pillow.readthedocs.io/en/latest/installation.html#building-from-source)