### PR TITLE
Change Flake8 options and reduce pylint no-self-use warns for music_grabber.py

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are syntax errors/undefined names/long lines
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --ignore=W503 --select=E,F,W,C --show-source --statistics
         flake8 . --count --max-complexity=10 --max-line-length=79 --statistics

--- a/config_example.py
+++ b/config_example.py
@@ -25,10 +25,10 @@ ABOUT_HTML = ("This bot is going to manage cpop.tw.\n"
               "whenever you send the link and makes new members go through "
               "captcha.\n\n"
               "<i>Source code available at cpop.tw/code under GPLv3 "
-              "license</i>\n\n" +
-              CONTACTS_HTML)
-HELP_HTML = (AVAILABILITY_HTML +
-             "\n\n<b>Usage</b>:\n"
+              "license</i>\n\n"
+              + CONTACTS_HTML)
+HELP_HTML = (AVAILABILITY_HTML
+             + "\n\n<b>Usage</b>:\n"
              "- send a message that only contains a link of a YouTube video "
              "or a SoundCloud track.\n"
              "- Playlists are not supported, but you can select multiple "
@@ -36,8 +36,8 @@ HELP_HTML = (AVAILABILITY_HTML +
              "- Your message will be deleted in private chat after the music "
              "gets successfully uploaded.\n"
              "- You can get YouTube links with inline bot @vid and use "
-             "them.\n\n" +
-             CONTACTS_HTML)
+             "them.\n\n"
+             + CONTACTS_HTML)
 
 # Music will be temporary downloaded to this destination
 # and then automatically deleted once the bot uploaded it

--- a/cpop_bot/music_grabber.py
+++ b/cpop_bot/music_grabber.py
@@ -17,102 +17,101 @@ class WrongFileSizeError(ValueError):
     pass
 
 
-class MusicDownloader:
+def download_audio(input_url, filesize_limit):
+    input_url = input_url.split('&list', 1)[0]
+    ydl_opts = {
+        'format': 'bestaudio[protocol^=http]',
+        'logger': logger,
+        'outtmpl': DOWNLOAD_DIR
+        + '%(title)s - %(extractor)s-%(id)s.%(ext)s',
+        'writethumbnail': True
+    }
+    ydl = YoutubeDL(ydl_opts)
+    info = ydl.extract_info(input_url, download=False)
+    webpage_info = info['extractor'] + " " + info['id']
+    info_format = next((item for item in info['formats']
+                        if item['format_id'] == info['format_id']), None)
 
-    def download(self, input_url, filesize_limit):
-        input_url = input_url.split('&list', 1)[0]
-        ydl_opts = {
-            'format': 'bestaudio[protocol^=http]',
-            'logger': logger,
-            'outtmpl': DOWNLOAD_DIR
-            + '%(title)s - %(extractor)s-%(id)s.%(ext)s',
-            'writethumbnail': True
-        }
-        ydl = YoutubeDL(ydl_opts)
-        info = ydl.extract_info(input_url, download=False)
-        webpage_info = info['extractor'] + " " + info['id']
-        info_format = next((item for item in info['formats']
-                            if item['format_id'] == info['format_id']),
-                           None)
+    if _youtube_video_not_music(info):
+        raise WrongCategoryError(webpage_info + ": not under Music category")
 
-        if self.youtube_video_not_music(info):
-            raise WrongCategoryError(webpage_info
-                                     + ": not under Music category")
+    audio_filesize = _get_filesize(info_format)
+    if int(audio_filesize) > filesize_limit:
+        raise WrongFileSizeError(webpage_info + ": audio file size ("
+                                 + str(audio_filesize) + ") is greater"
+                                 + "than the limit: (" + str(filesize_limit)
+                                 + ")")
 
-        audio_filesize = self.__get_filesize(info_format)
-        if int(audio_filesize) > filesize_limit:
-            raise WrongFileSizeError(webpage_info + ": audio file size ("
-                                     + str(audio_filesize) + ") is greater"
-                                     + "than the limit: ("
-                                     + str(filesize_limit) + ")")
-
-        logger.info("%s: downloading...", webpage_info)
-        ydl.process_info(info)
-        info = self.__add_downloads_to_info_dict(info, ydl_opts)
-        if not self.__files_successfully_downloaded(info['downloads']):
-            self.__delete_downloaded_files(info['downloads'])
-            raise ValueError(webpage_info
-                             + ": failed to download audio or thumbnail")
-        return info
-
-    def youtube_video_not_music(self, info):
-        if info['extractor'] == 'youtube' and \
-                'Music' not in info['categories']:
-            return True
-        return False
-
-    def __get_filesize(self, info_format):
-        if 'filesize' in info_format:
-            audio_filesize = info_format['filesize']
-        else:
-            audio_url = info_format['url']
-            http_headers = info_format['http_headers']
-            request_head = Request(audio_url, method='HEAD',
-                                   headers=http_headers)
-            audio_filesize = urlopen(request_head).headers['Content-Length']
-        return audio_filesize
-
-    def __add_downloads_to_info_dict(self, info, ydl_opts):
-        thumbnail_url = info['thumbnail']
-        audio_file = YoutubeDL(ydl_opts).prepare_filename(info)
-        thumbnail_file = audio_file.rsplit(".", 1)[-2] + "." + \
-            self.__get_file_extension_from_url(thumbnail_url)
-        info['downloads'] = {
-            'audio': audio_file,
-            'thumbnail': thumbnail_file
-        }
-        return info
-
-    def __files_successfully_downloaded(self, info_downloads):
-        return all(os.path.isfile(f) for f in info_downloads.values())
-
-    def __delete_downloaded_files(self, info_downloads):
-        for f in info_downloads.values():
-            try:
-                os.remove(f)
-            except OSError:
-                pass
-
-    def __get_file_extension_from_url(self, url):
-        url_path = urlparse(url).path
-        basename = os.path.basename(url_path)
-        return basename.split(".")[-1]
+    logger.info("%s: downloading...", webpage_info)
+    ydl.process_info(info)
+    info = _add_downloads_to_info_dict(info, ydl_opts)
+    if not _files_successfully_downloaded(info['downloads']):
+        _delete_downloaded_files(info['downloads'])
+        raise ValueError(webpage_info
+                         + ": failed to download audio or thumbnail")
+    return info
 
 
-class SquarethumbMaker:
+def _youtube_video_not_music(info):
+    if info['extractor'] == 'youtube' and 'Music' not in info['categories']:
+        return True
+    return False
 
-    # https://stackoverflow.com/a/52177551
-    def make_squarethumb(self, thumbnail, output):
-        original_thumb = Image.open(thumbnail)
-        squarethumb = self.__crop_to_square(original_thumb)
-        squarethumb.thumbnail((320, 320), Image.ANTIALIAS)
-        squarethumb.save(output)
 
-    def __crop_to_square(self, img):
-        width, height = img.size
-        length = min(width, height)
-        left = (width - length) / 2
-        top = (height - length) / 2
-        right = (width + length) / 2
-        bottom = (height + length) / 2
-        return img.crop((left, top, right, bottom))
+def _get_filesize(info_format):
+    if 'filesize' in info_format:
+        audio_filesize = info_format['filesize']
+    else:
+        audio_url = info_format['url']
+        http_headers = info_format['http_headers']
+        request_head = Request(audio_url, method='HEAD', headers=http_headers)
+        audio_filesize = urlopen(request_head).headers['Content-Length']
+    return audio_filesize
+
+
+def _add_downloads_to_info_dict(info, ydl_opts):
+    thumbnail_url = info['thumbnail']
+    audio_file = YoutubeDL(ydl_opts).prepare_filename(info)
+    thumbnail_file = audio_file.rsplit(".", 1)[-2] + "." + \
+        _get_file_extension_from_url(thumbnail_url)
+    info['downloads'] = {
+        'audio': audio_file,
+        'thumbnail': thumbnail_file
+    }
+    return info
+
+
+def _files_successfully_downloaded(info_downloads):
+    return all(os.path.isfile(f) for f in info_downloads.values())
+
+
+def _delete_downloaded_files(info_downloads):
+    for f in info_downloads.values():
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+
+
+def _get_file_extension_from_url(url):
+    url_path = urlparse(url).path
+    basename = os.path.basename(url_path)
+    return basename.split(".")[-1]
+
+
+# https://stackoverflow.com/a/52177551
+def make_squarethumb(thumbnail, output):
+    original_thumb = Image.open(thumbnail)
+    squarethumb = _crop_to_square(original_thumb)
+    squarethumb.thumbnail((320, 320), Image.ANTIALIAS)
+    squarethumb.save(output)
+
+
+def _crop_to_square(img):
+    width, height = img.size
+    length = min(width, height)
+    left = (width - length) / 2
+    top = (height - length) / 2
+    right = (width + length) / 2
+    bottom = (height + length) / 2
+    return img.crop((left, top, right, bottom))

--- a/cpop_bot/music_grabber.py
+++ b/cpop_bot/music_grabber.py
@@ -22,11 +22,11 @@ class MusicDownloader:
     def download(self, input_url, filesize_limit):
         input_url = input_url.split('&list', 1)[0]
         ydl_opts = {
-                'format': 'bestaudio[protocol^=http]',
-                'logger': logger,
-                'outtmpl': DOWNLOAD_DIR +
-                '%(title)s - %(extractor)s-%(id)s.%(ext)s',
-                'writethumbnail': True
+            'format': 'bestaudio[protocol^=http]',
+            'logger': logger,
+            'outtmpl': DOWNLOAD_DIR
+            + '%(title)s - %(extractor)s-%(id)s.%(ext)s',
+            'writethumbnail': True
         }
         ydl = YoutubeDL(ydl_opts)
         info = ydl.extract_info(input_url, download=False)
@@ -36,23 +36,23 @@ class MusicDownloader:
                            None)
 
         if self.youtube_video_not_music(info):
-            raise WrongCategoryError(webpage_info +
-                                     ": not under Music category")
+            raise WrongCategoryError(webpage_info
+                                     + ": not under Music category")
 
         audio_filesize = self.__get_filesize(info_format)
         if int(audio_filesize) > filesize_limit:
-            raise WrongFileSizeError(webpage_info + ": audio file size (" +
-                                     str(audio_filesize) + ") is greater" +
-                                     "than the limit: (" +
-                                     str(filesize_limit) + ")")
+            raise WrongFileSizeError(webpage_info + ": audio file size ("
+                                     + str(audio_filesize) + ") is greater"
+                                     + "than the limit: ("
+                                     + str(filesize_limit) + ")")
 
         logger.info("%s: downloading...", webpage_info)
         ydl.process_info(info)
         info = self.__add_downloads_to_info_dict(info, ydl_opts)
         if not self.__files_successfully_downloaded(info['downloads']):
             self.__delete_downloaded_files(info['downloads'])
-            raise ValueError(webpage_info +
-                             ": failed to download audio or thumbnail")
+            raise ValueError(webpage_info
+                             + ": failed to download audio or thumbnail")
         return info
 
     def youtube_video_not_music(self, info):
@@ -78,8 +78,8 @@ class MusicDownloader:
         thumbnail_file = audio_file.rsplit(".", 1)[-2] + "." + \
             self.__get_file_extension_from_url(thumbnail_url)
         info['downloads'] = {
-                'audio': audio_file,
-                'thumbnail': thumbnail_file
+            'audio': audio_file,
+            'thumbnail': thumbnail_file
         }
         return info
 
@@ -111,8 +111,8 @@ class SquarethumbMaker:
     def __crop_to_square(self, img):
         width, height = img.size
         length = min(width, height)
-        left = (width - length)/2
-        top = (height - length)/2
-        right = (width + length)/2
-        bottom = (height + length)/2
+        left = (width - length) / 2
+        top = (height - length) / 2
+        right = (width + length) / 2
+        bottom = (height + length) / 2
         return img.crop((left, top, right, bottom))

--- a/cpop_bot/new_members_handler.py
+++ b/cpop_bot/new_members_handler.py
@@ -68,8 +68,8 @@ class NewMembersHandler:
 
     async def __purge_old_captchas(self):
         for pending_user in self.pending_users:
-            time_passed = (datetime.now() -
-                           pending_user.timestamp).total_seconds() / 60
+            time_passed = (datetime.now()
+                           - pending_user.timestamp).total_seconds() / 60
             if time_passed > USER_CAPTCHA_TIMEOUT_IN_MINUTES:
                 self.pending_users.remove(pending_user)
                 await pending_user.captcha_message.delete()


### PR DESCRIPTION
Flake8: Enable all errors and warnings except W503

> W503 (*) | line break before binary operator
> W504 (*) | line break after binary operator

https://pycodestyle.pycqa.org/en/latest/intro.html#features

W503 and W504 are conflicted and PEP 8 recommends W504 style now.
