### PR TITLE
Made a fixed length log for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,8 @@ services:
     volumes:
       - .:/usr/src/app
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"


### PR DESCRIPTION
I had a problem that the log file would grow to tens of gigabytes